### PR TITLE
dynamic template with ps support

### DIFF
--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -22,7 +22,9 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
         }
       }
 
-      $elem.perfectScrollbar(options);
+      $scope.$evalAsync(function() {
+        $elem.perfectScrollbar(options);
+      });
 
       function update() {
         $scope.$evalAsync(function() {


### PR DESCRIPTION
When loading template dynamically - such as template of popover/tooltip in angular strap the thumb size is 0 because relevant element ps-scrollbar-x-rail.css('borderTopWidth) is equal to '' which results in NaN which leads to thumb size of 0.
