### PR TITLE
Calling safely apply (avoid digest already in progress)

### DIFF
--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -49,10 +49,21 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
 
         // This is necessary if you aren't watching anything for refreshes
         if(!$scope.$$phase) {
-          $scope.$apply();
+          $scope.safeApply();
         }
 
       }
+
+      $scope.safeApply = function(fn) {
+        var phase = this.$root.$$phase;
+        if(phase == '$apply' || phase == '$digest') {
+          if(fn && (typeof(fn) === 'function')) {
+            fn();
+          }
+        } else {
+          this.$apply(fn);
+        }
+      };
 
       // This is necessary when you don't watch anything with the scrollbar
       $elem.bind('mouseenter', update('mouseenter'));


### PR DESCRIPTION
PR to call safely apply using it from https://coderwall.com/p/ngisma

Last code it seems to be broke:

```
Error: [$rootScope:inprog] $digest already in progress
  2 http://errors.angularjs.org/1.2.18/$rootScope/inprog?p0=%24digest
  3     at http://localhost:3000/bower_components/angular/angular.js:78:12
  4     at beginPhase (http://localhost:3000/bower_components/angular/angular.js:12864:15)
  5     at Scope.$get.Scope.$apply (http://localhost:3000/bower_components/angular/angular.js:12653:11)
  6     at Scope.ng.config.$provide.decorator.$delegate.__proto__.$apply (<anonymous>:855:30)
  7     at update (http://localhost:3000/bower_components/angular-perfect-scrollbar/src/angular-perfect-scrollbar.js:52:18)
  8     at link (http://localhost:3000/bower_components/angular-perfect-scrollbar/src/angular-perfect-scrollbar.js:58:32)
  9     at nodeLinkFn (http://localhost:3000/bower_components/angular/angular.js:6633:13)
 10     at compositeLinkFn (http://localhost:3000/bower_components/angular/angular.js:6028:13)
 11     at publicLinkFn (http://localhost:3000/bower_components/angular/angular.js:5923:30)
 12     at b.all.then.c (http://localhost:3000/bower_components/angular-dashboard-framework/dist/angular-dashboard-framework.min.js:2:4201)
 13
 14
 15  // This is necessary if you aren't watching anything for refreshes
 16                     if (!$scope.$$phase) {
 17                         $scope.$apply();
 18                     }
 19
 20 // This is necessary when you don't watch anything with the scrollbar
 21       $elem.bind('mouseenter', update('mouseenter'));
```
