### PR TITLE
automatically update if content's height has changed

### DIFF
--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -36,7 +36,17 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
           })
         });
       });
-
+      //watch for content size dynamically changes
+      $scope.$watch(
+        function() {
+          return $elem.prop("scrollHeight");
+        },
+        function(newValue, oldValue) {
+            if (newValue) {
+               update('contentSizeChange');
+            }
+        }
+      );
       function update(event) {
         $scope.$evalAsync(function() {
           if ($attr.scrollDown == 'true' && event != 'mouseenter') {


### PR DESCRIPTION
Ran into an issue when adding/removing content while not mousing out of a perfect-scrollbar element. The update() isn't triggered until a user tries to scorll. Instead of calling update() each time, I added this watch to do automatically call update() when the scorllHeight has changed.

*The 'contentSizeChange' param isn't being used in the update method it calls. Just to pass it in case of future needs.
