### PR TITLE
calculate height when mouseenter

### DIFF
--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -43,13 +43,17 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
             setTimeout(function () {
               $($elem).scrollTop($($elem).prop("scrollHeight"));
             }, 100);
+          }else if (event =="mouseenter"){
+            $elem.data('perfect-scrollbar-update')();
           }
           $elem.perfectScrollbar('update');
         });
       }
 
       // This is necessary when you don't watch anything with the scrollbar
-      $elem.bind('mouseenter', update('mouseenter'));
+        $elem.bind('mouseenter',function() {
+        update('mouseenter');
+      });
 
       // Possible future improvement - check the type here and use the appropriate watch for non-arrays
       if ($attr.refreshOnChange) {


### PR DESCRIPTION
I'm trying to use perfect scrollbar in a bootstrap modal window.
Unfortunately, when $elem.perfectScrollar() is fired, $elem.prop('scrollHeight') equals 0. As a result, there is no scrollbar neither scroll. 
Firing data binded perfect-scrollbar-update on mouseenter, allows to get real height and set correct properties for scrollbars.

By the way writing 

``` javascript
$elem.bind('mouseenter', update('mouseenter')); 
```

doesn't trigger mouseenter action each time mouse enters, but

``` javascript
   $elem.bind('mouseenter',function() { 
update('mouseenter');
});
```

does... I don't know why.
