### PR TITLE
Bower throws error when trying to use 0.4.11 version of perfect-scrollbar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "scrollbar"
   ],
   "dependencies": {
-    "perfect-scrollbar": "~0.4.11",
+    "perfect-scrollbar": "~0.4.2",
     "angular": "*"
   },
   "authors": [


### PR DESCRIPTION
Looks like bower can no longer resolve 0.4.11. I get the following error when I try to install this package with 0.4.11

```
bower ENORESTARGET  No tag found that was able to satisfy ~0.4.11

Additional error details:
Available versions: 0.5.9, 0.5.8, 0.5.7, 0.5.6, 0.5.5, 0.5.4, 0.5.3, 0.5.2, 0.5.1, 0.4.9, 0.4.8, 0.4.7, 0.4.6, 0.4.5, 0.4.4, 0.4.3, 0.4.2, 0.4.1, 0.3.4, 0.3.3, 0.3.2, 0.3.1, 0.2.5, 0.2.4, 0.2.3, 0.2.2, 0.2.1
```
