### PR TITLE
Gathered few other PRs and code reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Config file for kissdigital
+
+# No .editorconfig files above the root directory
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Use 4 spaces for indentation in HTML, JavaScript, Ruby, SCSS, Less, and XML
+
+[*.{html,js,rb,scss,xml,md,less}]
+indent_size = 4

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,25 @@
+{
+  "strict": false,
+  "browser": true,
+  "globalstrict": true,
+  "bitwise": true,
+  "indent": 4,
+  "globals": {
+    "after": false,
+    "afterEach": false,
+    "angular": false,
+    "before": false,
+    "element": false,
+    "by": false,
+    "beforeEach": false,
+    "browser": false,
+    "describe": false,
+    "expect": false,
+    "inject": false,
+    "it": false,
+    "jasmine": false,
+    "spyOn": false,
+    "$": false,
+    "_": false
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-perfect-scrollbar",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A directive to allow the use of perfect scrollbar in angular",
   "main": "src/angular-perfect-scrollbar.js",
   "keywords": [
@@ -22,6 +22,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    ".editorconfig",
+    ".jshintrc"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-perfect-scrollbar",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": false,
   "scripts": {
     "test": "grunt"

--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -1,73 +1,93 @@
-angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
-  ['$parse', '$window', function($parse, $window) {
-  var psOptions = [
+var psOptions = [
     'wheelSpeed', 'wheelPropagation', 'minScrollbarLength', 'useBothWheelAxes',
     'useKeyboard', 'suppressScrollX', 'suppressScrollY', 'scrollXMarginOffset',
     'scrollYMarginOffset', 'includePadding'//, 'onScroll', 'scrollDown'
-  ];
+];
 
-  return {
-    restrict: 'EA',
-    transclude: true,
-    template: '<div><div ng-transclude></div></div>',
-    replace: true,
-    link: function($scope, $elem, $attr) {
-      var jqWindow = angular.element($window);
-      var options = {};
+angular
+    .module('perfect_scrollbar', [])
+    .directive('perfectScrollbar', ['$parse', '$window', perfectScrollbar]);
 
-      for (var i=0, l=psOptions.length; i<l; i++) {
-        var opt = psOptions[i];
-        if ($attr[opt] !== undefined) {
-          options[opt] = $parse($attr[opt])();
+
+function perfectScrollbar($parse, $window) {
+    return {
+        restrict: 'EA',
+        transclude: true,
+        template: '<div><div ng-transclude></div></div>',
+        replace: true,
+        link: function perfectScrollbarLink($scope, $elem, $attr) {
+            var jqWindow = angular.element($window);
+            var options = {};
+
+            var updateResize = updateOfReason('resize');
+            var updateMouseEnter = updateOfReason('mouseenter');
+            var updateChange = updateOfReason('change');
+            var updateChangeDelayed = function () {
+                setTimeout(updateChange, 150);
+            };
+
+            for (var i = 0, l = psOptions.length; i < l; i++) {
+                var opt = psOptions[i];
+                if ($attr[opt] !== undefined) {
+                    options[opt] = $parse($attr[opt])();
+                }
+            }
+
+            $scope.$evalAsync(function () {
+                $elem.perfectScrollbar(options);
+                var onScrollHandler = $parse($attr.onScroll);
+                $elem.scroll(function () {
+                    var scrollTop = $elem.scrollTop();
+                    var scrollHeight = $elem.prop('scrollHeight') - $elem.height();
+                    $scope.$apply(function () {
+                        onScrollHandler($scope, {
+                            scrollTop: scrollTop,
+                            scrollHeight: scrollHeight
+                        })
+                    })
+                });
+            });
+
+
+            // Possible future improvement - check the type here and use the appropriate watch for non-arrays
+            if ($attr.refreshOnChange) {
+                $scope.$watchCollection($attr.refreshOnChange, updateChangeDelayed);
+            } else {
+                $scope.$watch(function () {
+                    return $elem.children('[ng-transclude]').prop('scrollHeight');
+                }, updateChange);
+            }
+
+            // This is necessary when you don't watch anything with the scrollbar
+            $elem.on('mouseenter', updateMouseEnter);
+
+            jqWindow.on('resize', updateResize);
+
+            $elem.on('$destroy', function () {
+                jqWindow.off('resize', updateResize);
+                $elem.perfectScrollbar('destroy');
+            });
+
+
+            function update(event) {
+                $scope.$evalAsync(function () {
+                    if ($attr.scrollDown == 'true' && event != 'mouseenter') {
+                        setTimeout(function () {
+                            $elem.scrollTop($elem.prop("scrollHeight"));
+                        }, 100);
+                    }
+                    $elem.perfectScrollbar('update');
+                });
+            }
+
+            function updateOfReason(eventName) {
+                return function () {
+                    update(eventName);
+                };
+            }
+
+
         }
-      }
 
-      $scope.$evalAsync(function() {
-        $elem.perfectScrollbar(options);
-        var onScrollHandler = $parse($attr.onScroll)
-        $elem.scroll(function(){
-          var scrollTop = $elem.scrollTop()
-          var scrollHeight = $elem.prop('scrollHeight') - $elem.height()
-          $scope.$apply(function() {
-            onScrollHandler($scope, {
-              scrollTop: scrollTop,
-              scrollHeight: scrollHeight
-            })
-          })
-        });
-      });
-
-      function update(event) {
-        $scope.$evalAsync(function() {
-          if ($attr.scrollDown == 'true' && event != 'mouseenter') {
-            setTimeout(function () {
-              $($elem).scrollTop($($elem).prop("scrollHeight"));
-            }, 100);
-          }
-          $elem.perfectScrollbar('update');
-        });
-      }
-
-      // This is necessary when you don't watch anything with the scrollbar
-      $elem.bind('mouseenter', update('mouseenter'));
-
-      // Possible future improvement - check the type here and use the appropriate watch for non-arrays
-      if ($attr.refreshOnChange) {
-        $scope.$watchCollection($attr.refreshOnChange, function() {
-          update();
-        });
-      }
-
-      // this is from a pull request - I am not totally sure what the original issue is but seems harmless
-      if ($attr.refreshOnResize) {
-        jqWindow.on('resize', update);
-      }
-
-      $elem.bind('$destroy', function() {
-        jqWindow.off('resize', update);
-        $elem.perfectScrollbar('destroy');
-      });
-
-    }
-  };
-}]);
+    };
+}


### PR DESCRIPTION
I looked at others PRs and noticed that others had same problem as me. I needed to solve it better however.

It still uses refreshOnChange, however it is very likely that other task that is performing async operation will redraw and stretch contents after that operation, so it should be delayed... but I do not know how to know how long after first init and i know i wont ever know that :)
So.. it should be removed in future.

Other method is to watch content height (it is happening when refreshOnChange attr is not filled) and react to it. It is watched by a angular watcher cause it should change on digest.
