### PR TITLE
add: add a hook function to reset scrollbar from any other controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 angular-perfect-scrollbar
 =========================
 
+### Note For This Forked Repo
+This project is a forked repo by [angular-perfect-scrollbar](https://github.com/noraesae/perfect-scrollbar), since author maintain it inactively, we need fix some bugs and add some available features, so publish this repo to bower "angular-live-scrollbar"
+
 This is a small directive to allow the use of [perfect-scrollbar](https://github.com/noraesae/perfect-scrollbar) in angular.
 
 You can just use the file (in the *src* directory) as is - you only need to pay attention to the other stuff for further development.  It is also available on [Bower](http://bower.io) as 'angular-perfect-scrollbar'.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "angular-perfect-scrollbar",
-  "version": "0.0.4",
-  "description": "A directive to allow the use of perfect scrollbar in angular",
+  "name": "angular-live-scrollbar",
+  "version": "0.0.1",
+  "description": "A directive to allow the use of perfect scrollbar in angular, with some other new features by jimubox.com",
   "main": "src/angular-perfect-scrollbar.js",
   "keywords": [
     "angular",
@@ -13,10 +13,11 @@
     "angular": "*"
   },
   "authors": [
-    "Drew Miller"
+    "Drew Miller",
+    "Yang He"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/itsdrewmiller/angular-perfect-scrollbar",
+  "homepage": "https://github.com/abruzzihraig/angular-perfect-scrollbar",
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-live-scrollbar",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "A directive to allow the use of perfect scrollbar in angular, with some other new features by jimubox.com",
   "main": "src/angular-perfect-scrollbar.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular-perfect-scrollbar",
+  "name": "angular-live-scrollbar",
   "version": "0.0.4",
   "private": false,
   "scripts": {

--- a/src/angular-perfect-scrollbar.js
+++ b/src/angular-perfect-scrollbar.js
@@ -3,7 +3,7 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
   var psOptions = [
     'wheelSpeed', 'wheelPropagation', 'minScrollbarLength', 'useBothWheelAxes',
     'useKeyboard', 'suppressScrollX', 'suppressScrollY', 'scrollXMarginOffset',
-    'scrollYMarginOffset', 'includePadding'//, 'onScroll', 'scrollDown'
+    'scrollYMarginOffset', 'includePadding', 'resetPosition'//, 'onScroll', 'scrollDown'
   ];
 
   return {
@@ -11,6 +11,9 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
     transclude: true,
     template: '<div><div ng-transclude></div></div>',
     replace: true,
+    scope: {
+      reset: '&resetPosition'
+    },
     link: function($scope, $elem, $attr) {
       var jqWindow = angular.element($window);
       var options = {};
@@ -68,6 +71,12 @@ angular.module('perfect_scrollbar', []).directive('perfectScrollbar',
         $elem.perfectScrollbar('destroy');
       });
 
+      $scope.resetPosition = function(x, y) {
+        $($elem).scrollTop(y || 0);
+        $($elem).scrollLeft(x || 0);
+      }
+
+      $scope.reset({fn: $scope.resetPosition});
     }
   };
 }]);


### PR DESCRIPTION
Hi guys,

I have a requirement about how to update the position of scrollbar, actually I need a hook function which could be call from outer controllers.
For instance, I have a list which has been scrolled to bottom, now I will switch or reset data of list, then the scrollbar should be reset to top.

Effect like below:
![switch-to-init](https://cloud.githubusercontent.com/assets/3356523/8200388/e503f836-14f6-11e5-90c1-9e93f0d64fa6.gif)

For that I added a proxy function to the scrollbar directive, and then we can call the hook function from outer like:
### HTML

```
<perfect-scrollbar class="scroll-content" reset-position="set_scrollbar_hook(fn)" wheel-propagation="true" wheel-speed="2" min-scrollbar-length="20" lr-infinite-scroll="load_more" scroll-threshold="200" time-threshold="300">
    <div class="news-content">
        <div class="news-item" ng-repeat="news in news_list">
            <h3 class="news-title">{{news.title}}</h3>
            <section class="news-content">
                <p>{{news.content}}</p>
            </section>
        </div>
    </div>
</perfect-scrollbar>
```
### In any other controllers

```
// load news with or without specific date, default is now
$scope.load_news = (date) => {
    $scope.news_list = _.shuffle($scope.news_list.slice(0, 5));
    $scope.reset_scrollbar(0, 30);
};

// set hook fn from scrollbar directive
$scope.set_scrollbar_hook = (fn) => $scope.reset_scrollbar = fn;
```
